### PR TITLE
Remove user from playbooks

### DIFF
--- a/openstack-installer/ansible.cfg
+++ b/openstack-installer/ansible.cfg
@@ -1,0 +1,4 @@
+[defaults]
+hostfile = inventory/inventory.py
+force_handlers = True
+remote_user = ansible

--- a/openstack-installer/ceph.yml
+++ b/openstack-installer/ceph.yml
@@ -1,7 +1,6 @@
 ---
 
 - hosts: ceph_monitor
-  user: ansible
   sudo: True
   max_fail_percentage: 0
   roles:
@@ -9,7 +8,6 @@
     - ceph_monitor
 
 - hosts: ceph_osd
-  user: ansible
   sudo: True
   max_fail_percentage: 0
   roles:

--- a/openstack-installer/ceph_radosgw.yml
+++ b/openstack-installer/ceph_radosgw.yml
@@ -1,7 +1,6 @@
 ---
 
 - hosts: ceph_radosgw[0]
-  user: ansible
   max_fail_percentage: 0
   roles:
     - os_keystone_service
@@ -16,7 +15,6 @@
     keystone_projects: []
 
 - hosts: ceph_radosgw
-  user: ansible
   sudo: True
   max_fail_percentage: 0
   roles:
@@ -27,7 +25,6 @@
     ceph_keyring_owner: root
 
 - hosts: ceph_radosgw
-  user: ansible
   sudo: True
   max_fail_percentage: 0
   roles:
@@ -35,7 +32,6 @@
     - ceph_radosgw
 
 - hosts: haproxy
-  user: ansible
   sudo: True
   max_fail_percentage: 0
   roles:

--- a/openstack-installer/galera.yml
+++ b/openstack-installer/galera.yml
@@ -1,7 +1,6 @@
 ---
 
 - hosts: galera
-  user: ansible
   sudo: True
   max_fail_percentage: 0
   roles:
@@ -14,7 +13,6 @@
       - { keyserver: "keys.gnupg.net", keyid: "1C4CBDCDCD2EFD2A" }
 
 - hosts: haproxy
-  user: ansible
   sudo: True
   max_fail_percentage: 0
   roles:

--- a/openstack-installer/haproxy.yml
+++ b/openstack-installer/haproxy.yml
@@ -1,7 +1,6 @@
 ---
 
 - hosts: haproxy
-  user: ansible
   sudo: True
   max_fail_percentage: 0
   roles:

--- a/openstack-installer/memcached.yml
+++ b/openstack-installer/memcached.yml
@@ -1,7 +1,6 @@
 ---
 
 - hosts: memcached
-  user: ansible
   sudo: True
   max_fail_percentage: 0
   roles:

--- a/openstack-installer/mongodb.yml
+++ b/openstack-installer/mongodb.yml
@@ -1,7 +1,6 @@
 ---
 
 - hosts: mongodb
-  user: ansible
   sudo: True
   max_fail_percentage: 0
   roles:

--- a/openstack-installer/os_ceilometer.yml
+++ b/openstack-installer/os_ceilometer.yml
@@ -1,6 +1,5 @@
 ---
 - hosts: ceilometer_controller[0]
-  user: ansible
   max_fail_percentage: 0
   roles:
     - os_keystone_service
@@ -21,7 +20,6 @@
         keystone_role: admin
 
 - hosts: ceilometer_controller[0]
-  user: ansible
   max_fail_percentage: 0
   roles:
     - os_keystone_service
@@ -42,7 +40,6 @@
         keystone_role: admin
 
 - hosts: mongodb
-  user: ansible
   sudo: True
   max_fail_percentage: 0
   tasks:
@@ -62,7 +59,6 @@
 - hosts:
     - ceilometer_controller
     - ceilometer_compute
-  user: ansible
   sudo: True
   max_fail_percentage: 0
   roles:
@@ -70,7 +66,6 @@
     - os_ceilometer
 
 - hosts: haproxy
-  user: ansible
   sudo: True
   max_fail_percentage: 0
   roles:

--- a/openstack-installer/os_cinder.yml
+++ b/openstack-installer/os_cinder.yml
@@ -1,7 +1,6 @@
 ---
 
 - hosts: cinder[0]
-  user: ansible
   max_fail_percentage: 0
   roles:
     - os_keystone_service
@@ -22,7 +21,6 @@
         keystone_role: admin
 
 - hosts: cinder[0]
-  user: ansible
   max_fail_percentage: 0
   roles:
     - os_keystone_service
@@ -38,7 +36,6 @@
 - hosts:
     - cinder
     - cinder_volume
-  user: ansible
   sudo: True
   max_fail_percentage: 0
   roles:
@@ -46,7 +43,6 @@
     - os_cinder
 
 - hosts: cinder
-  user: ansible
   sudo: True
   max_fail_percentage: 0
   roles:
@@ -57,7 +53,6 @@
     ceph_keyring_owner: cinder
 
 - hosts: cinder
-  user: ansible
   sudo: True
   max_fail_percentage: 0
   roles:
@@ -68,7 +63,6 @@
     ceph_keyring_owner: cinder
 
 - hosts: haproxy
-  user: ansible
   sudo: True
   max_fail_percentage: 0
   roles:

--- a/openstack-installer/os_glance.yml
+++ b/openstack-installer/os_glance.yml
@@ -1,7 +1,6 @@
 ---
 
 - hosts: glance[0]
-  user: ansible
   max_fail_percentage: 0
   roles:
     - os_keystone_service
@@ -22,7 +21,6 @@
         keystone_role: admin
 
 - hosts: glance
-  user: ansible
   sudo: True
   max_fail_percentage: 0
   roles:
@@ -30,7 +28,6 @@
     - os_glance
 
 - hosts: glance
-  user: ansible
   sudo: True
   max_fail_percentage: 0
   roles:
@@ -41,7 +38,6 @@
     ceph_keyring_owner: glance
 
 - hosts: haproxy
-  user: ansible
   sudo: True
   max_fail_percentage: 0
   roles:

--- a/openstack-installer/os_heat.yml
+++ b/openstack-installer/os_heat.yml
@@ -1,7 +1,6 @@
 ---
 
 - hosts: heat[0]
-  user: ansible
   max_fail_percentage: 0
   roles:
     - os_keystone_service
@@ -22,7 +21,6 @@
         keystone_role: admin
 
 - hosts: heat[0]
-  user: ansible
   max_fail_percentage: 0
   roles:
     - os_keystone_service
@@ -36,7 +34,6 @@
     keystone_region: "{{ keystone_region_name }}"
 
 - hosts: heat
-  user: ansible
   sudo: True
   max_fail_percentage: 0
   roles:
@@ -44,7 +41,6 @@
     - os_heat
 
 - hosts: haproxy
-  user: ansible
   sudo: True
   max_fail_percentage: 0
   roles:

--- a/openstack-installer/os_horizon.yml
+++ b/openstack-installer/os_horizon.yml
@@ -1,7 +1,6 @@
 ---
 
 - hosts: horizon
-  user: ansible
   sudo: True
   max_fail_percentage: 0
   roles:
@@ -9,7 +8,6 @@
     - os_horizon
 
 - hosts: haproxy
-  user: ansible
   sudo: True
   max_fail_percentage: 0
   roles:

--- a/openstack-installer/os_ironic.yml
+++ b/openstack-installer/os_ironic.yml
@@ -1,7 +1,6 @@
 ---
 
 - hosts: ironic[0]
-  user: ansible
   max_fail_percentage: 0
   roles:
     - os_keystone_service
@@ -22,7 +21,6 @@
         keystone_role: admin
 
 - hosts: ironic
-  user: ansible
   sudo: True
   max_fail_percentage: 0
   roles:
@@ -30,7 +28,6 @@
     - os_ironic
 
 - hosts: haproxy
-  user: ansible
   sudo: True
   max_fail_percentage: 0
   roles:

--- a/openstack-installer/os_keystone.yml
+++ b/openstack-installer/os_keystone.yml
@@ -1,7 +1,6 @@
 ---
 
 - hosts: keystone
-  user: ansible
   sudo: True
   max_fail_percentage: 0
   roles:
@@ -9,7 +8,6 @@
     - os_keystone
 
 - hosts: haproxy
-  user: ansible
   sudo: True
   max_fail_percentage: 0
   roles:
@@ -44,7 +42,6 @@
 #so the controller[0] host is there
 
 - hosts: controller[0]
-  user: ansible
   sudo: True
   max_fail_percentage: 0
   tasks:
@@ -52,7 +49,6 @@
       apt: name=python-keystoneclient
 
 - hosts: controller[0]
-  user: ansible
   max_fail_percentage: 0
   roles:
     - os_keystone_service

--- a/openstack-installer/os_murano.yml
+++ b/openstack-installer/os_murano.yml
@@ -1,7 +1,6 @@
 ---
 
 - hosts: murano[0]
-  user: ansible
   max_fail_percentage: 0
   roles:
     - os_keystone_service
@@ -22,7 +21,6 @@
         keystone_role: admin
 
 - hosts: murano
-  user: ansible
   sudo: True
   max_fail_percentage: 0
   roles:
@@ -30,7 +28,6 @@
     - os_murano
 
 - hosts: haproxy
-  user: ansible
   sudo: True
   max_fail_percentage: 0
   roles:

--- a/openstack-installer/os_neutron.yml
+++ b/openstack-installer/os_neutron.yml
@@ -1,7 +1,6 @@
 ---
 
 - hosts: neutron_controller[0]
-  user: ansible
   max_fail_percentage: 0
   roles:
     - os_keystone_service
@@ -24,7 +23,6 @@
 - hosts:
     - neutron_controller
     - neutron_compute
-  user: ansible
   sudo: True
   max_fail_percentage: 0
   roles:
@@ -32,7 +30,6 @@
     - os_neutron
 
 - hosts: haproxy
-  user: ansible
   sudo: True
   max_fail_percentage: 0
   roles:

--- a/openstack-installer/os_nova.yml
+++ b/openstack-installer/os_nova.yml
@@ -1,7 +1,6 @@
 ---
 
 - hosts: nova_controller[0]
-  user: ansible
   max_fail_percentage: 0
   roles:
     - os_keystone_service
@@ -24,7 +23,6 @@
 - hosts:
     - nova_controller
     - nova_compute
-  user: ansible
   sudo: True
   max_fail_percentage: 0
   roles:
@@ -32,7 +30,6 @@
     - os_nova
 
 - hosts: nova_compute
-  user: ansible
   sudo: True
   max_fail_percentage: 0
   roles:
@@ -55,7 +52,6 @@
     ceph_keyring_owner: nova
 
 - hosts: haproxy
-  user: ansible
   sudo: True
   max_fail_percentage: 0
   roles:

--- a/openstack-installer/os_sahara.yml
+++ b/openstack-installer/os_sahara.yml
@@ -1,7 +1,6 @@
 ---
 
 - hosts: sahara[0]
-  user: ansible
   max_fail_percentage: 0
   roles:
     - os_keystone_service
@@ -22,7 +21,6 @@
         keystone_role: admin
 
 - hosts: sahara
-  user: ansible
   sudo: True
   max_fail_percentage: 0
   roles:
@@ -30,7 +28,6 @@
     - os_sahara
 
 - hosts: haproxy
-  user: ansible
   sudo: True
   max_fail_percentage: 0
   roles:

--- a/openstack-installer/os_trove.yml
+++ b/openstack-installer/os_trove.yml
@@ -1,7 +1,6 @@
 ---
 
 - hosts: trove[0]
-  user: ansible
   max_fail_percentage: 0
   roles:
     - os_keystone_service
@@ -26,7 +25,6 @@
         keystone_role: admin
 
 - hosts: trove
-  user: ansible
   sudo: True
   max_fail_percentage: 0
   roles:
@@ -34,7 +32,6 @@
     - os_trove
 
 - hosts: haproxy
-  user: ansible
   sudo: True
   max_fail_percentage: 0
   roles:

--- a/openstack-installer/pacemaker.yml
+++ b/openstack-installer/pacemaker.yml
@@ -1,7 +1,6 @@
 ---
 
 - hosts: pacemaker
-  user: ansible
   sudo: True
   serial: 1
   max_fail_percentage: 0
@@ -10,7 +9,6 @@
       fetch: src=/etc/corosync/authkey dest=workdir/authkey fail_on_missing=False flat=True
 
 - hosts: pacemaker
-  user: ansible
   sudo: True
   max_fail_percentage: 0
   roles:

--- a/openstack-installer/rabbitmq.yml
+++ b/openstack-installer/rabbitmq.yml
@@ -1,7 +1,6 @@
 ---
 
 - hosts: rabbitmq
-  user: ansible
   sudo: True
   max_fail_percentage: 0
   roles:

--- a/openstack-installer/syslog-ng.yml
+++ b/openstack-installer/syslog-ng.yml
@@ -1,7 +1,6 @@
 ---
 
 - hosts: mongodb
-  user: ansible
   sudo: True
   max_fail_percentage: 0
   tasks:
@@ -16,7 +15,6 @@
       when: syslog_use_mongodb and mongo_master.stdout == 'true'
 
 - hosts: syslog
-  user: ansible
   sudo: True
   max_fail_percentage: 0
   roles:


### PR DESCRIPTION
Allows different ssh user on managed nodes and do not hardcode 'ansible'. Eg. vagrant boxes are pre-packed with 'vagrant' user. Now it is possible to set user in ansible.cfg or in the inventory.
