### PR TITLE
Use os.path.join instead of string concatenation

### DIFF
--- a/openstack-installer/inventory/inventory.py
+++ b/openstack-installer/inventory/inventory.py
@@ -31,7 +31,8 @@ def expand_group(yml, group, nesting_level):
 
 def inventory(hostname):
 
-    with open(os.path.dirname(sys.argv[0])+"/inventory.yml", 'r') as f:
+    with open(os.path.join(os.path.dirname(sys.argv[0]),
+                           "inventory.yml"), 'r') as f:
         yml = yaml.safe_load(f)
 
     if hostname:

--- a/openstack-installer/scripts/generate_secrets.py
+++ b/openstack-installer/scripts/generate_secrets.py
@@ -28,4 +28,5 @@ def generate_secrets(filename):
     with open(filename, 'w') as f:
         f.write(''.join(secrets))
 
-generate_secrets(os.path.dirname(sys.argv[0])+"/../group_vars/all/secrets.yml")
+generate_secrets(os.path.join(
+    os.path.dirname(sys.argv[0]), "..", "group_vars/all/secrets.yml"))

--- a/openstack-installer/scripts/generate_secrets.py
+++ b/openstack-installer/scripts/generate_secrets.py
@@ -29,4 +29,4 @@ def generate_secrets(filename):
         f.write(''.join(secrets))
 
 generate_secrets(os.path.join(
-    os.path.dirname(sys.argv[0]), "..", "group_vars/all/secrets.yml"))
+    os.path.dirname(sys.argv[0]), "..", "group_vars", "all", "secrets.yml"))


### PR DESCRIPTION
As linux is the only target the path separator is always / but nicer to use os.path.join
