### PR TITLE
Mongodb fix

### DIFF
--- a/openstack-installer/roles/mongodb/tasks/main.yml
+++ b/openstack-installer/roles/mongodb/tasks/main.yml
@@ -46,6 +46,8 @@
   run_once: True
   when: mongo_initialized == False
   until: mongo_status.stdout == '1'
+  retries: 10
+  delay: 5
 
 - name: determine the master node
   command: mongo --quiet --eval 'rs.isMaster().ismaster' admin
@@ -55,6 +57,8 @@
 - name: ensure the admin user exists
   mongodb_user: database=admin name=admin password={{ mongodb_admin_password }} roles=userAdminAnyDatabase
   when: mongo_master.stdout == 'true'
+  register: mongo_admin
+  failed_when: mongo_admin | failed and "not authorized for query" not in mongo_admin.msg
 
 - name: ensure the cluster admin user exists
   mongodb_user: database=admin login_user=admin login_password={{ mongodb_admin_password }}


### PR DESCRIPTION
- increase retry count for mongodb status: default 'retries: 3' was
  not enough in some cases
- add failed_when to admin user creation: mongodb_user module has
  changed in Ansible 2.0, which results in failure on subsequent runs
  because it does not use authenticate() to check user existence
