### PR TITLE
Fix os_keystone multiple when

### DIFF
--- a/openstack-installer/roles/os_keystone/tasks/main.yml
+++ b/openstack-installer/roles/os_keystone/tasks/main.yml
@@ -110,9 +110,10 @@
 
 - name: rotate fernet keys
   command: su keystone -s /bin/sh -c "/usr/bin/keystone-manage fernet_rotate --keystone-user keystone --keystone-group keystone"
-  when: not keystone_fernet_init | changed
+  when:
+    - keystone_token_provider == 'fernet'
+    - not keystone_fernet_init | changed
   run_once: True
-  when: keystone_token_provider == 'fernet'
 
 - name: distribute fernet keys
   command: su keystone -s /bin/sh -c


### PR DESCRIPTION
A task in os_keystone role contains 2 when clause
which causes a warning in Ansible 2.0
